### PR TITLE
Automatically load components on startup

### DIFF
--- a/helm/spacecrafts/templates/deployment.yaml
+++ b/helm/spacecrafts/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
           args: ["python manage.py serve
                   --command 'migrate'
                   --command 'collectstatic --no-input'
+                  --command 'loaddata components'
                   --port {{ .Values.containerPort.portNumber }}
                   --probe-port {{ .Values.containerProbePort }}
                   {{- if .Values.serveStatic }}


### PR DESCRIPTION
This simplifies the usage of the helm charts since we don't require the users to run a command inside the container to even get the application started.